### PR TITLE
Add agents config with install script

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,0 +1,13 @@
+# Instructions
+
+## Pull request summaries
+
+Do not include standard CI-covered verification steps in PR summaries, such as "run the test suite" or "verify the change builds." CI already covers those, and reviewers generally won't repeat them locally. Only list manual verification steps that CI can't cover, such as UI checks or behavior that needs a human to observe.
+
+## Branch naming
+
+Use `mick/branch-name` for new branches by default. If the work comes from an issue tracker, prefer fetching the expected branch name directly from the tracker when that functionality is available. Otherwise, if the tracker provides an expected branch name through some other readily available means, use that name. Do not spend extra time searching for tracker-specific branch conventions; if the expected name is not readily available, fall back to the `mick/branch-name` convention.
+
+## Bugfixes with tests
+
+When fixing a bug or issue, add the regression test before implementing the fix. Confirm that the test fails for the expected reason. A test written after the fix may also pass against the buggy code, which means it would not catch the bug if it were reintroduced.

--- a/agents/install.bash
+++ b/agents/install.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE="$SCRIPT_DIRECTORY/AGENTS.md"
+
+print_and_run () {
+    echo "$@"
+    "$@"
+}
+
+link_agents_md () {
+    local dir="$1"
+    local name="$2"
+    local link_path="$HOME/$dir/$name"
+
+    print_and_run mkdir -p "$HOME/$dir"
+
+    if [ -L "$link_path" ] || [ -e "$link_path" ]; then
+        if [ -L "$link_path" ] && [ "$(readlink -f "$link_path")" = "$SOURCE" ]; then
+            echo "$link_path already links to $SOURCE"
+            return
+        fi
+        print_and_run rm "$link_path"
+    fi
+
+    print_and_run ln --symbolic "$SOURCE" "$link_path"
+}
+
+link_agents_md ".codex" "AGENTS.md"
+link_agents_md ".claude" "CLAUDE.md"


### PR DESCRIPTION
## Summary
- Add `agents/AGENTS.md` as the single source of agent instructions (PR summaries, branch naming, bugfix tests).
- Add `agents/install.bash` to symlink `agents/AGENTS.md` into `~/.codex/AGENTS.md` and `~/.claude/CLAUDE.md` so both Codex and Claude share the same user-level config.

## Test plan
- [ ] Run `agents/install.bash` on a fresh machine and confirm both symlinks resolve to `agents/AGENTS.md`.
- [ ] Re-run `agents/install.bash` and confirm it is idempotent.